### PR TITLE
fix: post display order

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -132,9 +132,9 @@ const MainPage = () => {
         </div>
         <br />
         <br />
-<div className='flex bg-white border-0 shadow-2xl hover:shadow-blue-500/20 transform hover:scale-[1.02] transition-all duration-200 items-center justify-center rounded-2xl ring-1 ring-gray-900/5 p-1'>
-  <SearchBar />
-</div>
+          <div className='flex bg-white border-0 shadow-2xl hover:shadow-blue-500/20 transform hover:scale-[1.02] transition-all duration-200 items-center justify-center rounded-2xl ring-1 ring-gray-900/5 p-1'>
+            <SearchBar />
+          </div>
         <br />
         <div className="grid grid-cols-1 gap-6">
           {posts.map((dataPoint) => (

--- a/src/lib/get-posts.ts
+++ b/src/lib/get-posts.ts
@@ -12,7 +12,19 @@ export async function getPosts(): Promise<undefined | DisplayPost[]> {
     return undefined
   }
 
-  return await getDisplayPosts(posts as SocialPost[]);
+  // Step 1: Sort by date (most recent first)
+  const sortedByDate = posts.sort((a, b) =>
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+
+  // Step 2: Take random number between 10-15 posts
+  const randomCount = Math.floor(Math.random() * 6) + 10; // Random between 10-15
+  const topRecentPosts = sortedByDate.slice(0, randomCount);
+
+  // Step 3: Sort those posts by likes (highest first)
+  const finalOrdered = topRecentPosts.sort((a, b) => b.likes - a.likes);
+
+  return await getDisplayPosts(finalOrdered as SocialPost[]);
 }
 
 export async function getPostById(postId: number): Promise<undefined | DisplayPost> {


### PR DESCRIPTION
Fixing post display order with the following logic:

- Posts are ordered by publication time, from most recent to oldest
- The first 10-15 posts are order not only by time, but also by number of likes


